### PR TITLE
chore: add npm metadata links

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
   "main": "dist/index.js",
   "type": "commonjs",
   "repository": "github:OneBusAway/js-sdk",
+  "homepage": "https://github.com/OneBusAway/js-sdk#readme",
+  "bugs": {
+    "url": "https://github.com/OneBusAway/js-sdk/issues"
+  },
   "license": "Apache-2.0",
   "packageManager": "yarn@1.22.22",
   "files": [


### PR DESCRIPTION
﻿## Summary

This adds the npm package metadata links that are currently missing from `package.json`:

- `homepage` points to the repository README
- `bugs.url` points to the repository issue tracker

No runtime code, exports, dependencies, or generated files are changed.

## Verification

- `node -e "const p=require('./package.json'); if (p.bugs?.url !== 'https://github.com/OneBusAway/js-sdk/issues' || p.homepage !== 'https://github.com/OneBusAway/js-sdk#readme') process.exit(1)"`
- `git diff --cached --check`
- `npm pack --dry-run --json --ignore-scripts`
- `corepack yarn install --frozen-lockfile --ignore-scripts`
- `.\node_modules\.bin\tsc.cmd --noEmit`
- `.\node_modules\.bin\jest.cmd --runInBand tests/stringifyQuery.test.ts tests/responses.test.ts`

I also exported the committed tree into WSL Ubuntu 26.04 with LF line endings and verified:

- `npm pkg get homepage bugs --json`
- `npm pack --dry-run --json --ignore-scripts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project metadata to include homepage and bug reporting information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->